### PR TITLE
UI fix for settings,receive page,overview,history,help and tickets page

### DIFF
--- a/app/src/main/java/com/decrediton/activities/SettingsActivity.java
+++ b/app/src/main/java/com/decrediton/activities/SettingsActivity.java
@@ -45,7 +45,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                         if(address.equals("")){
                             System.out.println("Starting local dcrd 1");
                             util.setBoolean(getString(R.string.key_connection_local_dcrd),true);
-                            Toast.makeText(getActivity(), "Set remote address first", Toast.LENGTH_SHORT).show();
+                            Toast.makeText(getActivity(), R.string.info_set_remote_addr, Toast.LENGTH_SHORT).show();
                             return false;
                         }else{
                             System.out.println("Not Starting local dcrd");
@@ -68,7 +68,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                         util.set(getActivity().getString(R.string.remote_dcrd), o.toString());
                         return true;
                     }else{
-                        Toast.makeText(getActivity(), "Remote address is invalid", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(getActivity(), R.string.remote_address_invalid, Toast.LENGTH_SHORT).show();
                     }
                     return false;
                 }

--- a/app/src/main/java/com/decrediton/activities/SplashScreen.java
+++ b/app/src/main/java/com/decrediton/activities/SplashScreen.java
@@ -76,6 +76,8 @@ public class SplashScreen extends AppCompatActivity implements Animation.Animati
         }else{
             openWallet();
         }
+
+
     }
 
     private void setText(final String str){
@@ -101,7 +103,7 @@ public class SplashScreen extends AppCompatActivity implements Animation.Animati
                         e.printStackTrace();
                     }
                 }
-                Intent i = new Intent(SplashScreen.this, SetupWalletActivity.class);
+                Intent i = new Intent(SplashScreen.this, MainActivity.class);
                 startActivity(i);
                 finish();
             }
@@ -147,20 +149,20 @@ public class SplashScreen extends AppCompatActivity implements Animation.Animati
                             @Override
                             public void run() {
                                 new AlertDialog.Builder(SplashScreen.this)
-                                        .setTitle("Error")
-                                        .setMessage("Could not connect to dcrd after 10 attempts")
-                                        .setPositiveButton("RETRY", new DialogInterface.OnClickListener() {
+                                        .setTitle(R.string.error_camel)
+                                        .setMessage(R.string.error_msg_could_not_connect_dcrd_10_secs)
+                                        .setPositiveButton(R.string.retry_caps, new DialogInterface.OnClickListener() {
                                             @Override
                                             public void onClick(DialogInterface dialogInterface, int i) {
                                                 load();
                                             }
-                                        }).setNegativeButton("EXIT", new DialogInterface.OnClickListener() {
+                                        }).setNegativeButton(R.string.exit_cap, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialogInterface, int i) {
                                         Dcrwallet.exit();
                                         finish();
                                     }
-                                }).setNeutralButton("SETTINGS", new DialogInterface.OnClickListener() {
+                                }).setNeutralButton(R.string.settings_cap, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialogInterface, int i) {
                                         Intent intent = new Intent(SplashScreen.this,SettingsActivity.class);
@@ -190,7 +192,7 @@ public class SplashScreen extends AppCompatActivity implements Animation.Animati
                     util.set(PreferenceUtil.BLOCK_HEIGHT, String.valueOf(blockHeight));
                 }
                 System.out.println("Finished fetching headers");
-                setText("Publish Unmined Transactions");
+                setText(getString(R.string.publish_unmined_transaction));
                 try {
                     Dcrwallet.publishUnminedTransactions();
                 } catch (Exception e) {

--- a/app/src/main/res/layout/content_help.xml
+++ b/app/src/main/res/layout/content_help.xml
@@ -1,6 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
     android:layout_height="match_parent">
+    <TextView
+        android:id="@+id/help_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="For more information please visit"
+        android:textColor="@color/colorText"
+        android:textSize="18sp"
+        android:layout_centerInParent="true"
+        />
+    <TextView
+        android:id="@+id/website_link"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:lines="2"
+        android:text="https://docs.decred.org"
+        android:textColor="@color/ButtonColor"
+        android:textSize="18sp"
+        android:layout_below="@+id/help_info"
+        android:layout_centerInParent="true"
+        />
 
-</android.support.constraint.ConstraintLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/content_history.xml
+++ b/app/src/main/res/layout/content_history.xml
@@ -1,15 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
-
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/history_recycler_view"
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginBottom="5dp"
-        android:layout_weight="1"
+        android:layout_height="wrap_content">
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/history_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginBottom="5dp"
+         />
+    </android.support.v4.widget.SwipeRefreshLayout>
+    <ProgressBar style="@android:style/Widget.DeviceDefault.Light.ProgressBar.Inverse"
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/progressContainers"
+        android:visibility="invisible"
+        android:layout_centerInParent="true"/>
+    <TextView
+        android:id="@+id/no_history"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:lines="2"
+        android:text="@string/no_transactions_n_tap_to_refresh"
+        android:textSize="21sp"
+        android:visibility="invisible"
+        android:layout_centerInParent="true"
         />
 
-</android.support.constraint.ConstraintLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/content_overview.xml
+++ b/app/src/main/res/layout/content_overview.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/backgcolor">
@@ -75,6 +75,10 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/recent_transactions"/>
+            <android.support.v4.widget.SwipeRefreshLayout
+                android:id="@+id/swipe_refresh_layout2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/history_recycler_view2"
@@ -82,9 +86,26 @@
                 android:layout_height="match_parent"
                 android:scrollbars="vertical"
                 android:layout_marginBottom="5dp"
-
                 />
+            </android.support.v4.widget.SwipeRefreshLayout>
         </LinearLayout>
     </LinearLayout>
+    <TextView
+        android:id="@+id/no_history"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:lines="2"
+        android:text="@string/no_transactions_n_tap_to_refresh"
+        android:textSize="21sp"
+        android:visibility="gone"
+        android:layout_centerInParent="true"
+        />
+    <ProgressBar style="@android:style/Widget.DeviceDefault.Light.ProgressBar.Inverse"
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/progressContainers"
+        android:visibility="invisible"
+        android:layout_centerInParent="true"/>
 
-</android.support.constraint.ConstraintLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/content_tickets.xml
+++ b/app/src/main/res/layout/content_tickets.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-</android.support.constraint.ConstraintLayout>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Coming soon..."
+        android:gravity="center"
+        android:textSize="26sp"
+        android:textColor="@color/colorText"
+        android:layout_centerInParent="true"
+        />
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <string name="available_balance">AVAILABLE BALANCE</string>
     <string name="rescan_block">Rescan Blockchain</string>
     <string name="recent_transactions">Recent Transactions</string>
-    <string name="receive_fund_privacy_info">Each time you request a payment,a new address is created to protect your privacy</string>
+    <string name="receive_fund_privacy_info">Each time you request a payment,\n a new address is created to protect your privacy</string>
     <string name="account">Account</string>
     <string name="receive_funds">Receive Funds</string>
     <string name="generate_new_address">Generate New Address</string>
@@ -106,7 +106,7 @@
     <string name="current_height">Current height</string>
     <string name="banscore">Banscore</string>
     <string name="syncode">Syncode</string>
-    <string name="loading">LOADING</string>
+    <string name="loading">Loading</string>
     <string name="transaction">Transaction</string>
     <string name="TxType">TxType</string>
     <string name="status">Status</string>
@@ -194,7 +194,7 @@
     <string name="pref_header_about">About</string>
     <string name="app_version">0.1 alpha</string>
     <string name="title_version">Version</string>
-    <string name="title_transaction_confirmation">Transaction Confirmation</string>
+    <string name="title_transaction_confirmation">Confirmations required</string>
     <string name="title_enable_local_dcrd">Enable local dcrd</string>
     <string name="title_testnet">Testnet</string>
     <string name="summary_testnet">Use testnet connection</string>
@@ -208,6 +208,24 @@
     <string name="remote_dcrd_address">Remote dcrd address</string>
     <string name="remote_dcrd">remote_dcrd</string>
     <string name="remote_certificate">remote_certificate</string>
+    <string name="information">Information</string>
+    <string name="refresh">refresh</string>
+    <string name="no_transactions_n_tap_to_refresh">No transactions   tap to refresh</string>
+    <string name="publish_unmined_transaction">Publish Unmined Transactions</string>
+    <string name="settings_cap">SETTINGS</string>
+    <string name="exit_cap">EXIT</string>
+    <string name="retry_caps">RETRY</string>
+    <string name="error_msg_could_not_connect_dcrd_10_secs">Could not connect to dcrd after 10 attempts</string>
+    <string name="error_camel">Error</string>
+    <string name="summary_block_height">Current block height</string>
+    <string name="title_block_height">Block height</string>
+    <string name="summary_rescan_blockchain">This will Rescan the Blockchain</string>
+    <string name="title_rescan_blockchain">Rescan Blockchain</string>
+    <string name="title_discover_address">Discover Address</string>
+    <string name="discover">discover</string>
+    <string name="summary_enable_local_dcrd">Changes will reflect on next launch</string>
+    <string name="remote_address_invalid">Remote address is invalid</string>
+    <string name="info_set_remote_addr">Set remote address first</string>
 
 
     <string-array name="pref_upload_quality_entries">

--- a/app/src/main/res/xml/pref_main.xml
+++ b/app/src/main/res/xml/pref_main.xml
@@ -5,29 +5,41 @@
             android:defaultValue="@string/default_transaction_confirmation"
             android:key="@string/key_transaction_confirmation"
             android:summary="@string/default_transaction_confirmation"
+
             android:title="@string/title_transaction_confirmation" />
 
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_title_connection">
-        <EditTextPreference
-            android:key="@string/remote_dcrd_address"
-            android:title="@string/remote_dcrd_address" />
         <SwitchPreference
             android:defaultValue="true"
-            android:summary="Changes will reflect on next launch"
+            android:summary="@string/summary_enable_local_dcrd"
             android:key="@string/key_connection_local_dcrd"
             android:title="@string/title_enable_local_dcrd" />
         <EditTextPreference
+            android:key="@string/remote_dcrd_address"
+            android:title="@string/remote_dcrd_address"
+            android:dependency="@string/key_connection_local_dcrd"/>
+        <EditTextPreference
+            android:dependency="@string/key_connection_local_dcrd"
             android:key="@string/key_connection_certificate"
             android:inputType="textMultiLine"
             android:summary="@string/summary_paste_certificate"
             android:title="@string/pref_title_certificate" />
+
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/information">
         <Preference
             android:summary="@string/summary_peers"
             android:title="@string/title_peers"
             android:key="@string/key_get_peers"
             />
+        <Preference
+            android:summary="@string/summary_block_height"
+            android:title="@string/title_block_height"
+            android:key="@string/key_get_peers"
+            />
+
     </PreferenceCategory>
 
     <CheckBoxPreference
@@ -37,8 +49,13 @@
         android:summary="@string/summary_testnet"
         android:title="@string/title_testnet" />
     <Preference
-        android:title="Discover Address"
-        android:key="discover"
+        android:summary="@string/summary_rescan_blockchain"
+        android:title="@string/title_rescan_blockchain"
+        android:key="@string/key_get_peers"
+        />
+    <Preference
+        android:title="@string/title_discover_address"
+        android:key="@string/discover"
         />
     <PreferenceCategory android:title="@string/pref_header_about">
         <Preference


### PR DESCRIPTION
 Adjustment of text on receive page,renamed transaction confirmation to confirmation required in settings,enabled local dcrd moved above remote dcrd address,added rescan blockchain to settings,moved peers and current block height under informations in settings,history to display No transaction when empty,ticket page displays coming soon,help page displays a link to docs.decred.org,implemented swipe down refresh for transaction list on history and overview page.
